### PR TITLE
Fix copy command

### DIFF
--- a/docs/dev/install/manual-install.md
+++ b/docs/dev/install/manual-install.md
@@ -44,7 +44,7 @@ pnpm client:build
 ```
 **Copy build to the `server` directory**
 ```bash
-cp -r client/build server/public
+cp -r client/build/. server/public
 ```
 ```bash
 cp client/build/index.html server/views/index.ejs


### PR DESCRIPTION
Originally the command made `build` directory at `server/public` making it `server/public/build` instead of copying all files from `client/build` into `server/public`

should fix https://github.com/RARgames/4gaBoards/issues/1038